### PR TITLE
Use waitress WSGI server for APIServer

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -15,6 +15,12 @@ from flask_jwt_extended import (
 import datetime,requests,subprocess,shlex,os,time
 import threading,queue,logging,json,pathlib,uuid
 
+try:
+    from waitress import serve as wsgi_serve
+    _HAVE_WAITRESS = True
+except ImportError:
+    _HAVE_WAITRESS = False
+
 from logging.handlers import SMTPHandler
 from logging import FileHandler
 
@@ -119,7 +125,7 @@ class APIServer:
         self.zeroconf = Zeroconf(ip_version=IPVersion.All)
         self.zeroconf.register_service(self.zeroconf_info)
         print("Started mDNS service advertisement.")
-    def run(self,**kwargs):
+    def run(self, use_waitress=None, **kwargs):
         if self.queue_daemon is None:
             raise ValueError('create_queue must be called before running server')
         if _ADVERTISE_ZEROCONF:
@@ -128,20 +134,43 @@ class APIServer:
             except Exception as e:
                 print(f'failed while trying to start zeroconf {e}, continuing')
         try:
-            self.app.run(**kwargs)
+            if use_waitress is None:
+                use_waitress = _HAVE_WAITRESS
+
+            if use_waitress:
+                if not _HAVE_WAITRESS:
+                    raise RuntimeError("waitress is not installed")
+                kwargs.setdefault('threads', 1)
+                wsgi_serve(self.app, **kwargs)
+            else:
+                kwargs.setdefault('use_debugger', False)
+                kwargs.setdefault('use_reloader', False)
+                self.app.run(**kwargs)
         finally:
             if _ADVERTISE_ZEROCONF:
                 self.zeroconf.unregister_service(self.zeroconf_info)
                 self.zeroconf.close()
 
-    def run_threaded(self,start_thread=True,**kwargs):
+    def run_threaded(self, start_thread=True, use_waitress=None, **kwargs):
         if self.queue_daemon is None:
             raise ValueError('create_queue must be called before running server')
         if _ADVERTISE_ZEROCONF:
             self.advertise_zeroconf(**kwargs)
-        
-        
-        thread = threading.Thread(target=self.app.run,daemon=True,kwargs=kwargs)
+
+        if use_waitress is None:
+            use_waitress = _HAVE_WAITRESS
+
+        if use_waitress:
+            if not _HAVE_WAITRESS:
+                raise RuntimeError("waitress is not installed")
+            kwargs.setdefault('threads', 1)
+            target = wsgi_serve
+        else:
+            kwargs.setdefault('use_debugger', False)
+            kwargs.setdefault('use_reloader', False)
+            target = self.app.run
+
+        thread = threading.Thread(target=target,daemon=True,kwargs=kwargs)
         if start_thread:
             thread.start()
         else:

--- a/AFL/automation/shared/launcher.py
+++ b/AFL/automation/shared/launcher.py
@@ -134,7 +134,9 @@ def _reconstitute_objects(obj_dict,data=None):
 
 parser = argparse.ArgumentParser(prog = f'AFL // {main_module_name}',
                                 description = f'AFL APIServer launcher for {main_module_name}')
-parser.add_argument('-i', '--interactive', action= 'store_true')
+parser.add_argument('-i', '--interactive', action='store_true')
+parser.add_argument('--no-waitress', action='store_true',
+                    help='Disable the waitress WSGI server')
 
 args = parser.parse_args()
 
@@ -152,13 +154,19 @@ server.init_logging(toaddrs=AFL_GLOBAL_CONFIG['owner_email'])
 
 #process = subprocess.Popen(['/bin/bash','-c',f'chromium-browser --start-fullscreen http://localhost:{server_port}'])#, shell=True, stdout=subprocess.PIPE)
 if args.interactive:
-        server.run_threaded(host=AFL_GLOBAL_CONFIG['bind_address'], port=server_port, debug=False)#,threaded=False)
+        server.run_threaded(host=AFL_GLOBAL_CONFIG['bind_address'],
+                            port=server_port,
+                            debug=False,
+                            use_waitress=None if not args.no_waitress else False)
         import code,time
         time.sleep(1) # this is mostly cosmetic, to let the server spin up.
         code.interact(local=globals(), banner = 'AFL APIServer started.  Access driver in "driver" global object, APIServer in "server".  Exit with ctrl-D or exit().  Have a lot of fun...')
 
 else:
-        server.run(host=AFL_GLOBAL_CONFIG['bind_address'], port=server_port, debug=False)#,threaded=False)
+        server.run(host=AFL_GLOBAL_CONFIG['bind_address'],
+                   port=server_port,
+                   debug=False,
+                   use_waitress=None if not args.no_waitress else False)
 
 #process.wait()
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ Its core is the 'DeviceServer' API, a simple way of exposing functionality in si
 
 Specific deviceserver instances are provided for a variety of hardware used in the AFL platform: syringe pumps, valves, multiposition flow selectors, UV-Vis spectrometers, x-ray and neutron scattering instruments/beamlines.  There are further deviceserver classes that integrate these base devices to perform higher-level functions, e.g. "loading".  These classes aim to specify instructions for running a particular protocol in a hardware-agnostic way.
 
+
+### Production deployment
+By default the APIServer will use the [waitress](https://docs.pylonsproject.org/projects/waitress/en/stable/) WSGI server if it is installed. To fall back to Flask's built-in server pass `--no-waitress` to `AFL.automation.shared.launcher`.

--- a/env.yml
+++ b/env.yml
@@ -27,6 +27,7 @@ dependencies:
   - pyserial
   - requests
   - flask_cors
+  - waitress
   - pyFAI
   - pip:
     - certif-pyspec=1.1.12

--- a/pkgs.txt
+++ b/pkgs.txt
@@ -20,5 +20,6 @@ scikit-image
 pyserial
 requests
 flask_cors
+waitress
 zeroconf
 

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -14,4 +14,5 @@ scikit-image
 pyserial
 requests
 flask_cors
+waitress
 tiled[client]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ scikit-image<0.20
 pyserial
 requests
 flask_cors
+waitress
 zeroconf
 #pyFAI
 #certif-pyspec==1.1.12


### PR DESCRIPTION
## Summary
- support running APIServer with waitress
- expose `--no-waitress` option in the launcher
- document waitress usage
- list waitress in environment requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test_common')*

------
https://chatgpt.com/codex/tasks/task_e_684c7f326a78832bb5ab762247691249