### PR TITLE
Fix rendering band and client API method typos

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -387,8 +387,13 @@ class APIServer:
             p.scatter(result[0],result[1],marker='circle', size=2,
                     line_color='navy', fill_color='orange', alpha=0.5)
             if len(result)>2:
-                errors = bokeh.models.Band(base=result[1],upper=result[1]+result[2],lower=result[1]-result[2], level='underlay',
-                fill_alpha=1.0, line_width=1, line_color='black')
+                band = bokeh.models.Band(base=result[1],
+                                         upper=result[1]+result[2],
+                                         lower=result[1]-result[2],
+                                         level='underlay',
+                                         fill_alpha=1.0,
+                                         line_width=1,
+                                         line_color='black')
                 p.add_layout(band)
 
         bokeh_js = JS_RESOURCES.render(

--- a/AFL/automation/APIServer/Client.py
+++ b/AFL/automation/APIServer/Client.py
@@ -64,8 +64,8 @@ class Client:
         self.token  = response.json()['token']
         self.headers = {'Authorization':'Bearer {}'.format(self.token)}
         if populate_commands:
-            self.get_queued_commmands()
-            self.get_unqueued_commmands()
+            self.get_queued_commands()
+            self.get_unqueued_commands()
         try:
             response = requests.post(self.url + '/get_queue_iteration',headers=self.headers)
             self.supports_queue_iteration = True
@@ -138,7 +138,7 @@ class Client:
             raise RuntimeError(f'API call to set_queue_mode command failed with status_code {response.status_code}\n{response.text}')
         return response.json()
 
-    def get_unqueued_commmands(self,inherit_commands=True):
+    def get_unqueued_commands(self,inherit_commands=True):
         response = requests.get(self.url+'/get_unqueued_commands',headers=self.headers)
         if response.status_code != 200:
             raise RuntimeError(f'API call to get_queued_commands command failed with status_code {response.status_code}\n{response.text}')
@@ -159,7 +159,7 @@ class Client:
                 
         return response.json()
         
-    def get_queued_commmands(self,inherit_commands=True):
+    def get_queued_commands(self,inherit_commands=True):
         response = requests.get(self.url+'/get_queued_commands',headers=self.headers)
         if response.status_code != 200:
             raise RuntimeError(f'API call to get_queued_commands command failed with status_code {response.status_code}\n{response.text}')


### PR DESCRIPTION
## Summary
- fix variable name when adding error band plot in APIServer
- rename Client methods to `get_queued_commands` and `get_unqueued_commands`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test_common')*

------
https://chatgpt.com/codex/tasks/task_e_6847817b7df4832bafefe8fabf806815