### PR TITLE
Fix deprecated pump status method

### DIFF
--- a/AFL/automation/loading/ChemyxSyringePump.py
+++ b/AFL/automation/loading/ChemyxSyringePump.py
@@ -149,9 +149,9 @@ class ChemyxSyringePump(SyringePump):
 
     def blockUntilStatusStopped(self,pollingdelay=0.2):
         '''
-        This is a deprecated function from old serial logic.  It should work, but do not use.  
+        This is a deprecated function from old serial logic.  It should work, but do not use.
         '''
-        self.wait_dosage_finished(self.pump,30)
+        self.wait_dosage_finished(30)
 
 
     def getStatus(self): #@TODO


### PR DESCRIPTION
## Summary
- correct call in `blockUntilStatusStopped`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test_common')*

------
https://chatgpt.com/codex/tasks/task_e_684784ce5064832b8f946ecbf7b80497