### PR TITLE
Fix typo in GPInterpolator error

### DIFF
--- a/AFL/automation/instrument/GPInterpolator.py
+++ b/AFL/automation/instrument/GPInterpolator.py
@@ -76,7 +76,7 @@ class Interpolator():
             # print('The set Y_coords')
             # print(self.Y_coord)
         except:
-            raise ValueError("One or more of the inputs X or Y are not correct. Check the defaluts")
+            raise ValueError("One or more of the inputs X or Y are not correct. Check the defaults")
        # print(self.X_raw.shape, self.Y_raw.shape)
         
         


### PR DESCRIPTION
## Summary
- correct a typo in `GPInterpolator`'s ValueError message

## Testing
- `grep -n "One or more" -n AFL/automation/instrument/GPInterpolator.py`


------
https://chatgpt.com/codex/tasks/task_e_684784cff840832bb6ee4034f6251cdc