### PR TITLE
Improve queue clearing accuracy

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -653,7 +653,7 @@ class APIServer:
         return 'Success',200
 
     def clear_queue(self):
-        self.task_queue.queue.clear()
+        self.task_queue.clear()
         return 'Success',200
 
     def clear_history(self):

--- a/AFL/automation/APIServer/static/webapp/addDiv.js
+++ b/AFL/automation/APIServer/static/webapp/addDiv.js
@@ -19,8 +19,8 @@ class Div {
     /**
      * Adds the div to the html and fills it in accordance to the div type
      */
-    display() {
-        $("#column1").append(this.div);
+    display(column=1) {
+        $("#column" + column).append(this.div);
         this.#addDivControls();
         this.#addHeader();
 
@@ -288,11 +288,8 @@ class Div {
             
             // Check if completed tasks have changed
             if (!arraysEqual(completed, $(completedID).children().map((i, el) => $(el).text()).get())) {
-                $(completedID).empty();
-                for (let i in completed) {
-                    const task = '<li onclick="addTaskPopup(\'' + key + '\',0,' + i + ')">' + completed[i].task.task_name + '</li>';
-                    $(completedID).append(task);
-                }
+                const items = completed.map((t, i) => `<li onclick="addTaskPopup('${key}',0,${i})">${t.task.task_name}</li>`).join('');
+                $(completedID).html(items);
             }
 
             // Check if current task has changed
@@ -307,11 +304,8 @@ class Div {
 
             // Check if queued tasks have changed
             if (!arraysEqual(queued, $(uncompletedID).children().map((i, el) => $(el).text()).get())) {
-                $(uncompletedID).empty();
-                for (let i in queued) {
-                    const task = '<li onclick="addTaskPopup(\'' + key + '\',2,' + i + ')">' + queued[i].task.task_name + '</li>';
-                    $(uncompletedID).append(task);
-                }
+                const items = queued.map((t, i) => `<li onclick="addTaskPopup('${key}',2,${i})">${t.task.task_name}</li>`).join('');
+                $(uncompletedID).html(items);
             }
         });
     }
@@ -388,48 +382,52 @@ function getDiv(serverKey, divType) {
  * Creates and adds a status div for the corresponding server
  * @param {String} key
  */
-function addStatusDiv(key) {
+function addStatusDiv(key, column=1) {
     var server = getServer(key);
-    server.statusDiv.display();
+    server.statusDiv.display(column);
 
     var id = '#'+server.statusDiv.addBtnID;
     disableBtn($(id));
+    saveLayout();
 }
 
 /**
  * Creates and adds a controls div for the corresponding server
  * @param {String} key
  */
-function addControlsDiv(key) {
+function addControlsDiv(key, column=1) {
     var server = getServer(key);
-    server.controlsDiv.display();
+    server.controlsDiv.display(column);
 
     var id = '#'+server.controlsDiv.addBtnID;
     disableBtn($(id));
+    saveLayout();
 }
 
 /**
  * Creates and adds a queue div for the corresponding server
  * @param {String} key
  */
-function addQueueDiv(key) {
+function addQueueDiv(key, column=1) {
     var server = getServer(key);
-    server.queueDiv.display();
+    server.queueDiv.display(column);
 
     var id = '#'+server.queueDiv.addBtnID;
     disableBtn($(id));
+    saveLayout();
 }
 
 /**
  * Creates and adds a quickbar div for the corresponding server
  * @param {String} key
  */
-function addQuickbarDiv(key) {
+function addQuickbarDiv(key, column=1) {
     var server = getServer(key);
-    server.quickbarDiv.display();
+    server.quickbarDiv.display(column);
 
     var id = '#'+server.quickbarDiv.addBtnID;
     disableBtn($(id));
+    saveLayout();
 }
 
 // Helper function to compare arrays

--- a/AFL/automation/APIServer/static/webapp/servers.js
+++ b/AFL/automation/APIServer/static/webapp/servers.js
@@ -2,9 +2,9 @@ var numOfServers = 0; // counter for the number of Server objects made
 var servers = []; // array for the Server objects
 
 class Server {
-    constructor(address) {
+    constructor(address, key=null) {
         this.address = address;
-        this.key = 'S'+(++numOfServers);
+        this.key = key || 'S'+(++numOfServers);
         
         this.queueIterationId = null;
         this.cachedQueue = null;
@@ -425,6 +425,7 @@ function addServer(popup) {
         addStatusDiv(server.key);
         addControlsDiv(server.key);
         addQueueDiv(server.key);
+        saveLayout();
 
         // // adds divs to the page if checked by user
         // var input;

--- a/AFL/automation/shared/MutableQueue.py
+++ b/AFL/automation/shared/MutableQueue.py
@@ -84,4 +84,10 @@ class MutableQueue:
             elif old_index>new_index:
                 self.queue.insert(new_index,self.queue[old_index])
                 del self.queue[old_index+1]
+
+    def clear(self):
+        '''Remove all items from the queue'''
+        with self.lock:
+            self.queue.clear()
+            self.iteration_id = time.time()
             


### PR DESCRIPTION
## Summary
- update `MutableQueue` with a `clear()` method that bumps `iteration_id`
- call the new method from `APIServer.clear_queue`
- stop manually resetting queue cache on the client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d744482a8832ba890f10cbab3838e