### PR TITLE
Fix config editor to preserve data types

### DIFF
--- a/AFL/automation/APIServer/static/config-retro.html
+++ b/AFL/automation/APIServer/static/config-retro.html
@@ -243,24 +243,20 @@ async function checkTaskCompletion(jwtToken, taskUUID) {
 }
 
 function stringifyValue(value) {
-    if (Array.isArray(value)) {
-        // If value is an array, stringify each element recursively
-        return `[${value.map(item => stringifyValue(item)).join(', ')}]`;
-    } else if (typeof value === 'object' && value !== null) {
-        // If value is an object (excluding arrays and null), stringify it
-        return JSON.stringify(value);
-    } else {
-        // Otherwise, return the original value as string
-        return String(value);
+    // Preserve plain strings for readability but JSON encode all other types.
+    // This ensures complex values round-trip correctly when edited.
+    if (typeof value === 'string') {
+        return value;
     }
+    return JSON.stringify(value);
 }
 
     function parseValue(valueString) {
+        // Trim whitespace then attempt JSON parsing. If parsing fails the
+        // value is treated as a simple string.
         try {
-            // Attempt to parse string value to JSON
-            return JSON.parse(valueString);
+            return JSON.parse(valueString.trim());
         } catch (error) {
-            // If parsing fails, return the original string value
             return valueString;
         }
     }

--- a/AFL/automation/APIServer/static/config.html
+++ b/AFL/automation/APIServer/static/config.html
@@ -225,24 +225,20 @@ async function checkTaskCompletion(jwtToken, taskUUID) {
 }
 
 function stringifyValue(value) {
-    if (Array.isArray(value)) {
-        // If value is an array, stringify each element recursively
-        return `[${value.map(item => stringifyValue(item)).join(', ')}]`;
-    } else if (typeof value === 'object' && value !== null) {
-        // If value is an object (excluding arrays and null), stringify it
-        return JSON.stringify(value);
-    } else {
-        // Otherwise, return the original value as string
-        return String(value);
+    // Preserve plain strings for readability but JSON encode all other types.
+    // This ensures complex values round-trip correctly when edited.
+    if (typeof value === 'string') {
+        return value;
     }
+    return JSON.stringify(value);
 }
 
     function parseValue(valueString) {
+        // Trim whitespace then attempt JSON parsing. If parsing fails the
+        // value is treated as a simple string.
         try {
-            // Attempt to parse string value to JSON
-            return JSON.parse(valueString);
+            return JSON.parse(valueString.trim());
         } catch (error) {
-            // If parsing fails, return the original string value
             return valueString;
         }
     }


### PR DESCRIPTION
## Summary
- improve serialization logic in the web config editor so lists and dicts aren't saved as strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7cd4760c832bb5a403922c4c61d8