### PR TITLE
Fix quickbar redraw on APIServer index

### DIFF
--- a/AFL/automation/APIServer/templates/index-new.html
+++ b/AFL/automation/APIServer/templates/index-new.html
@@ -307,11 +307,6 @@
                 updateTaskList("#queued", result[2], "queued");
             });
 
-            // Retrieve unqueued commands
-            $.get("/get_quickbar", function (data) {
-                displayCommands("#quickbar-commands", data);
-            });
-
             // Retrieve queued commands
             $.get("/get_queued_commands", function (data) {
                 displayCommands("#queued-commands", data);
@@ -385,7 +380,12 @@ function displayCommands(containerId, commands) {
     }
 }
 
-        // Initial update
+        // Populate quickbar controls once on page load
+        $.get("/get_quickbar", function (data) {
+            displayCommands("#quickbar-commands", data);
+        });
+
+        // Initial update of status information
         update();
         setInterval(update, 500); // Update every 0.5 seconds
         setTimeout(function () {


### PR DESCRIPTION
## Summary
- stop polling `/get_quickbar` on every update in the index page
- load quickbar buttons once when the page loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d72700b7c832ba23f37215a3e8c19