### PR TITLE
Remove tank level tracking from all loaders

### DIFF
--- a/AFL/automation/loading/OneSelectorBlowoutSampleCell.py
+++ b/AFL/automation/loading/OneSelectorBlowoutSampleCell.py
@@ -15,10 +15,7 @@ class OneSelectorBlowoutSampleCell(TwoSelectorBlowoutSampleCell):
 
     def __init__(self,pump,
                       selector,
-                      rinse_tank_level=950,
-                      waste_tank_level=0,
-                      cell_waste_tank_level=0,
-                      overrides=None, 
+                      overrides=None,
                       ):
         '''
             ncells = number of connected cells (up to 6 cells with a 10-position flow selector, with four positions taken by load port, rinse, waste, and air)
@@ -43,9 +40,7 @@ class OneSelectorBlowoutSampleCell(TwoSelectorBlowoutSampleCell):
         self.cell_state = defaultdict(lambda: 'clean')
         self.syringe_dirty = False
 
-        self.rinse_tank_level = rinse_tank_level
-        self.waste_tank_level = waste_tank_level
-        self.cell_waste_tank_level = cell_waste_tank_level
+
 
 
     def drySyringe(self,blow=True,waittime=1):

--- a/AFL/automation/loading/PneumaticPressureSampleCell.py
+++ b/AFL/automation/loading/PneumaticPressureSampleCell.py
@@ -41,9 +41,6 @@ class PneumaticPressureSampleCell(Driver,SampleCell):
     def __init__(self,pctrl,
                       relayboard,
                       digitalin=None,
-                      rinse1_tank_level=950,
-                      rinse2_tank_level=950,
-                      waste_tank_level=0,
                       load_stopper=None,
                       robot_interlock_host=None,
                       overrides=None,
@@ -65,9 +62,6 @@ class PneumaticPressureSampleCell(Driver,SampleCell):
         self.cell_state = defaultdict(lambda: 'clean')
         self.digitalin = digitalin
 
-        self.rinse1_tank_level = rinse1_tank_level
-        self.waste_tank_level = waste_tank_level
-        self.rinse2_tank_level = rinse2_tank_level
 
         self.loadStoppedExternally = False
         self.state = 'FRESH'
@@ -111,16 +105,7 @@ class PneumaticPressureSampleCell(Driver,SampleCell):
         else:
             self.load_stopper = None
 
-    @Driver.quickbar(qb={'button_text':'Reset Tank Levels',
-        'params':{
-        'rinse1':{'label':'Rinse1 (mL)','type':'float','default':950},
-        'rinse2':{'label':'Rinse2 (mL)','type':'float','default':950},
-        'waste':{'label':'Waste (mL)','type':'float','default':0}
-        }})
-    def reset_tank_levels(self,rinse1=950,rinse2=950,waste=0):
-        self.rinse1_tank_level = rinse1
-        self.waste_tank_level = waste
-        self.rinse2_tank_level = rinse2
+
 
     @property
     def app(self):
@@ -156,9 +141,6 @@ class PneumaticPressureSampleCell(Driver,SampleCell):
         status = []
         status.append(f'State: {self.state}')
         status.append(f'Arm State: {self.arm_state}')
-        status.append(f'Rinse 1 tank: {self.rinse1_tank_level} mL')
-        status.append(f'Rinse 2 tank: {self.rinse2_tank_level} mL')
-        status.append(f'Waste tank: {self.waste_tank_level} mL')
         status.append(f'Relay status: {self.relayboard.getChannels()}')
         if self._USE_ARM_LIMITS:
             status.append(f"Arm Up Limit: {self.digitalin.state['ARM_UP']} / Arm Down Limit{self.digitalin.state['ARM_DOWN']}")
@@ -351,12 +333,6 @@ class PneumaticPressureSampleCell(Driver,SampleCell):
     
     def rinseAll(self):
         self.rinseCell()
-
-    def setRinseLevel(self,vol):
-        self.rinse_tank_level = vol
-
-    def setWasteLevel(self,vol):
-        self.waste_tank_level = vol
 
     @Driver.quickbar(qb={'button_text':'Prime Rinse'})
     def primeRinse(self,waittime=10):

--- a/AFL/automation/loading/PneumaticSampleCell.py
+++ b/AFL/automation/loading/PneumaticSampleCell.py
@@ -38,11 +38,8 @@ class PneumaticSampleCell(Driver,SampleCell):
     def __init__(self,pump,
                       relayboard,
                       digitalin=None,
-                      rinse1_tank_level=950,
-                      rinse2_tank_level=950,
-                      waste_tank_level=0,
                       load_stopper=None,
-                      overrides=None, 
+                      overrides=None,
                       ):
         '''
             pump: a pump object supporting withdraw() and dispense() methods
@@ -61,9 +58,7 @@ class PneumaticSampleCell(Driver,SampleCell):
         self.cell_state = defaultdict(lambda: 'clean')
         self.digitalin = digitalin
 
-        self.rinse1_tank_level = rinse1_tank_level
-        self.waste_tank_level = waste_tank_level
-        self.rinse2_tank_level = rinse2_tank_level
+
 
         self.loadStoppedExternally = False
         self.state = 'FRESH'
@@ -110,16 +105,7 @@ class PneumaticSampleCell(Driver,SampleCell):
         self.pump.withdraw(self.config['withdraw_vol'])
         self.pump_level = self.config['withdraw_vol']
 
-    @Driver.quickbar(qb={'button_text':'Reset Tank Levels',
-        'params':{
-        'rinse1':{'label':'Rinse1 (mL)','type':'float','default':950},
-        'rinse2':{'label':'Rinse2 (mL)','type':'float','default':950},
-        'waste':{'label':'Waste (mL)','type':'float','default':0}
-        }})
-    def reset_tank_levels(self,rinse1=950,rinse2=950,waste=0):
-        self.rinse1_tank_level = rinse1
-        self.waste_tank_level = waste
-        self.rinse2_tank_level = rinse2
+
 
     @property
     def app(self):
@@ -138,9 +124,6 @@ class PneumaticSampleCell(Driver,SampleCell):
         status = []
         status.append(f'State: {self.state}')
         status.append(f'Arm State: {self.arm_state}')
-        status.append(f'Rinse 1 tank: {self.rinse1_tank_level} mL')
-        status.append(f'Rinse 2 tank: {self.rinse2_tank_level} mL')
-        status.append(f'Waste tank: {self.waste_tank_level} mL')
         status.append(f'Relay status: {self.relayboard.getChannels()}')
         if self._USE_ARM_LIMITS:
             status.append(f"Arm Up Limit: {not self.digitalin.state['ARM_UP']} / Arm Down Limit{not self.digitalin.state['ARM_DOWN']}")
@@ -272,11 +255,7 @@ class PneumaticSampleCell(Driver,SampleCell):
     def rinseAll(self):
         self.rinseCell()
 
-    def setRinseLevel(self,vol):
-        self.rinse_tank_level = vol
 
-    def setWasteLevel(self,vol):
-        self.waste_tank_level = vol
 
     @Driver.quickbar(qb={'button_text':'Prime Rinse'})
     def primeRinse(self,waittime=10):

--- a/AFL/automation/loading/RSoXSSolutionSampleCell.py
+++ b/AFL/automation/loading/RSoXSSolutionSampleCell.py
@@ -43,10 +43,7 @@ class RSoXSSolutionSampleCell(Driver,SampleCell):
 
     def __init__(self,pump,
                       selector,
-                      rinse_tank_level=950,
-                      waste_tank_level=0,
-                      cell_waste_tank_level=0,
-                      overrides=None, 
+                      overrides=None,
                       ):
         '''
             ncells = number of connected cells (up to 6 cells with a 10-position flow selector, with four positions taken by load port, rinse, waste, and air)
@@ -69,14 +66,6 @@ class RSoXSSolutionSampleCell(Driver,SampleCell):
         self.selector = selector
         self.syringe_dirty = False
 
-        self.rinse_tank_level = rinse_tank_level
-        self.waste_tank_level = waste_tank_level
-        self.cell_waste_tank_level = cell_waste_tank_level
-
-    def reset_tank_levels(self,rinse=950,waste=0,cell_waste=0):
-        self.rinse_tank_level = rinse
-        self.waste_tank_level = waste
-        self.cell_waste_tank_level = cell_waste
 
     @property
     def app(self):
@@ -95,9 +84,6 @@ class RSoXSSolutionSampleCell(Driver,SampleCell):
         status = []
         status.append(f'CellState: {dict(self.cell_state)}')
         status.append(f'SelectorState: {self.selector.portString}')
-        status.append(f'Rinse tank: {self.rinse_tank_level} mL')
-        status.append(f'Waste tank: {self.waste_tank_level} mL')
-        status.append(f'Cell Waste: {self.cell_waste_tank_level} mL')
         status.append(f'Pump: {self.pump.name}')
         status.append(f'Selector: {self.selector.name}')
         status.append(f'Cell: {self.name}')
@@ -124,14 +110,7 @@ class RSoXSSolutionSampleCell(Driver,SampleCell):
             self.selector.selectPort('waste')
             self.pump.dispense(vol_source-vol_dest)
 
-        if source == 'rinse':
-            self.rinse_tank_level -= vol_source
 
-        if dest == 'waste':
-            self.waste_tank_level += vol_dest
-
-        if dest == 'cell':
-            self.cell_waste_tank_level += min(vol_source,vol_dest)
 
 
     def catchToSyringe(self,sampleVolume=0):
@@ -321,10 +300,6 @@ class RSoXSSolutionSampleCell(Driver,SampleCell):
         self.rinseCatch()
         self.rinseSyringe()
 
-    def setRinseLevel(self,vol):
-        self.rinse_tank_level = vol
 
-    def setWasteLevel(self,vol):
-        self.waste_tank_level = vol
 
 

--- a/AFL/automation/loading/TwoSelectorBlowoutSampleCell.py
+++ b/AFL/automation/loading/TwoSelectorBlowoutSampleCell.py
@@ -44,10 +44,7 @@ class TwoSelectorBlowoutSampleCell(Driver,SampleCell):
     def __init__(self,pump,
                       selector,
                       blowselector,
-                      rinse_tank_level=950,
-                      waste_tank_level=0,
-                      cell_waste_tank_level=0,
-                      overrides=None, 
+                      overrides=None,
                       ):
         '''
             ncells = number of connected cells (up to 6 cells with a 10-position flow selector, with four positions taken by load port, rinse, waste, and air)
@@ -72,20 +69,6 @@ class TwoSelectorBlowoutSampleCell(Driver,SampleCell):
         self.cell_state = defaultdict(lambda: 'clean')
         self.syringe_dirty = False
 
-        self.rinse_tank_level = rinse_tank_level
-        self.waste_tank_level = waste_tank_level
-        self.cell_waste_tank_level = cell_waste_tank_level
-
-    @Driver.quickbar(qb={'button_text':'Reset Tank Levels',
-        'params':{
-        'rinse':{'label':'Rinse (mL)','type':'float','default':950},
-        'waste':{'label':'Waste (mL)','type':'float','default':950},
-        'cell_waste':{'label':'Cell Waste (mL)','type':'float','default':0}
-        }})
-    def reset_tank_levels(self,rinse=950,waste=0,cell_waste=0):
-        self.rinse_tank_level = rinse
-        self.waste_tank_level = waste
-        self.cell_waste_tank_level = cell_waste
 
     @property
     def app(self):
@@ -105,9 +88,6 @@ class TwoSelectorBlowoutSampleCell(Driver,SampleCell):
         status.append(f'CellState: {dict(self.cell_state)}')
         status.append(f'SelectorState: {self.selector.portString}')
         status.append(f'BlowSelectorState: {self.blowselector.portString}')
-        status.append(f'Rinse tank: {self.rinse_tank_level} mL')
-        status.append(f'Waste tank: {self.waste_tank_level} mL')
-        status.append(f'Cell Waste: {self.cell_waste_tank_level} mL')
         status.append(f'Pump: {self.pump.name}')
         status.append(f'Selector: {self.selector.name}')
         status.append(f'BlowSelector: {self.blowselector.name}')
@@ -135,14 +115,7 @@ class TwoSelectorBlowoutSampleCell(Driver,SampleCell):
             self.selector.selectPort('waste')
             self.pump.dispense(vol_source-vol_dest)
 
-        if source == 'rinse':
-            self.rinse_tank_level -= vol_source
 
-        if dest == 'waste':
-            self.waste_tank_level += vol_dest
-
-        if dest == 'cell':
-            self.cell_waste_tank_level += min(vol_source,vol_dest)
 
 
     def catchToSyringe(self,sampleVolume=0):
@@ -347,10 +320,6 @@ class TwoSelectorBlowoutSampleCell(Driver,SampleCell):
         self.rinseCatch()
         self.rinseSyringe()
 
-    def setRinseLevel(self,vol):
-        self.rinse_tank_level = vol
 
-    def setWasteLevel(self,vol):
-        self.waste_tank_level = vol
 
 


### PR DESCRIPTION
## Summary
- strip unused tank level fields and helpers across loader classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cecf49c6c832bb727299739d13050