### PR TITLE
Fix word wrap on new index page

### DIFF
--- a/AFL/automation/APIServer/templates/index-new.html
+++ b/AFL/automation/APIServer/templates/index-new.html
@@ -124,6 +124,11 @@
             margin-bottom: 20px;
         }
 
+        pre {
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
     </style>
     <title>{{ name }}</title>
 </head>
@@ -210,9 +215,11 @@
                 var newState = metaDiv.is(':visible') ? 'visible' : 'hidden';
                 localStorage.setItem(metaDiv[0].id, newState);
             });
+            var taskText = JSON.stringify(task, undefined, 2);
+            taskText = taskText.replace(/\\n/g, '\n');
             ul.append(
                 "<div class='meta' id='" + meta_str + "'><pre>" +
-                JSON.stringify(task, undefined, 2) + // Display full task JSON
+                taskText +
                 "</pre></div>"
             );
 


### PR DESCRIPTION
## Summary
- allow wrapping in `<pre>` blocks on new index page
- replace escaped newlines with real line breaks in driver task display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851dc1208e0832ba92c40ed245b5b22