### PR TITLE
Add prep target management in OT2HTTPDriver

### DIFF
--- a/AFL/automation/driver_templates/ot2_deck.html
+++ b/AFL/automation/driver_templates/ot2_deck.html
@@ -133,6 +133,32 @@ function resetTipracks(mount) {
         });
     });
 }
+function appendPrepTargets(targets) {
+    var t = targets.split(',');
+    login().then(function(tok) {
+        $.ajax({
+            type:"POST",
+            url:"/enqueue",
+            headers:{"Content-Type":"application/json","Authorization":"Bearer "+tok},
+            data: JSON.stringify({task_name:"add_prep_targets", targets: t, reset:false}),
+            success: function() { location.reload(); },
+            error: function(xhr) { alert("Error: "+xhr.responseText); }
+        });
+    });
+}
+function setPrepTargets(targets) {
+    var t = targets.split(',');
+    login().then(function(tok) {
+        $.ajax({
+            type:"POST",
+            url:"/enqueue",
+            headers:{"Content-Type":"application/json","Authorization":"Bearer "+tok},
+            data: JSON.stringify({task_name:"add_prep_targets", targets: t, reset:true}),
+            success: function() { location.reload(); },
+            error: function(xhr) { alert("Error: "+xhr.responseText); }
+        });
+    });
+}
 $(document).ready(function() {
     $('#load-instrument-btn').click(function() {
         var mount = $('#mount-select').val();

--- a/AFL/automation/prepare/OT2HTTPDriver.py
+++ b/AFL/automation/prepare/OT2HTTPDriver.py
@@ -31,7 +31,8 @@ class OT2HTTPDriver(Driver):
     defaults["loaded_labware"] = {}  # Persistent storage for loaded labware
     defaults["loaded_instruments"] = {}  # Persistent storage for loaded instruments
     defaults["loaded_modules"] = {}  # Persistent storage for loaded modules
-    defaults["available_tips"] = {} # Persistent storage for available tips, Format: {mount: [(tiprack_id, well_name), ...]}
+    defaults["available_tips"] = {}  # Persistent storage for available tips, Format: {mount: [(tiprack_id, well_name), ...]}
+    defaults["prep_targets"] = []  # Persistent storage for prep target well locations
 
     def __init__(self, overrides=None):
         self.app = None
@@ -48,7 +49,6 @@ class OT2HTTPDriver(Driver):
         self.protocol_id = None
         self.max_transfer = None
         self.min_transfer = None
-        self.prep_targets = []
         self.has_tip = False
         self.last_pipette = None
         self.modules = {}
@@ -180,21 +180,27 @@ class OT2HTTPDriver(Driver):
             raise RuntimeError(f"Error getting pipettes: {str(e)}")
 
     def reset_prep_targets(self):
-        self.prep_targets = []
+        """Clear the list of preparation targets stored in the config."""
+        self.config["prep_targets"] = []
+
 
     def add_prep_targets(self, targets, reset=False):
+        """Add well locations to the preparation target list."""
         if reset:
             self.reset_prep_targets()
-        self.prep_targets.extend(targets)
+        self.config.setdefault("prep_targets", [])
+        self.config["prep_targets"].extend(listify(targets))
+        self.config._update_history()
 
     def get_prep_target(self):
-        return self.prep_targets.pop(0)
+        return self.config["prep_targets"].pop(0)
 
     def status(self):
         status = []
-        if len(self.prep_targets) > 0:
-            status.append(f"Next prep target: {self.prep_targets[0]}")
-            status.append(f"Remaining prep targets: {len(self.prep_targets)}")
+        prep_targets = self.config.get("prep_targets", [])
+        if len(prep_targets) > 0:
+            status.append(f"Next prep target: {prep_targets[0]}")
+            status.append(f"Remaining prep targets: {len(prep_targets)}")
         else:
             status.append("No prep targets loaded")
 
@@ -309,6 +315,7 @@ class OT2HTTPDriver(Driver):
         self.config["loaded_instruments"] = {}
         self.config["loaded_modules"] = {}
         self.config["available_tips"] = {}
+        self.config["prep_targets"] = []
 
     @Driver.quickbar(qb={"button_text": "Home"})
     def home(self, **kwargs):
@@ -1921,6 +1928,7 @@ class OT2HTTPDriver(Driver):
                     'tiprack' in labware_type.lower() or
                     definition.get('metadata', {}).get('displayCategory') == 'tipRack'
                 )
+                wells = list(definition.get('wells', {}).keys())
                 mounts = []
                 if is_tiprack:
                     for m, d in self.config['loaded_instruments'].items():
@@ -1936,6 +1944,8 @@ class OT2HTTPDriver(Driver):
                     info['tiprack'] = True
                     info['mounts'] = mounts
                     info['color'] = '#fff3e0'
+                info['target_count'] = len(wells)
+                info['targets'] = ','.join([f"{slot_str}{w}" for w in wells])
             if has_module:
                 module_id, module_type = self.config["loaded_modules"][slot_str]
                 module_name = module_type.replace('ModuleV1', '').replace('Module', ' Mod')
@@ -1963,6 +1973,10 @@ class OT2HTTPDriver(Driver):
                     f"<button style='margin-top:4px;font-size:10px;' onclick=\"resetTipracks('{m}')\">Reset</button>"
                     for m in info.get('mounts', [])
                 ])
+                if info.get('target_count', 0) > 10:
+                    target_str = info.get('targets', '')
+                    info["buttons"] += f"<button style='margin-top:4px;font-size:10px;' onclick=\"appendPrepTargets('{target_str}')\">Append Targets</button>"
+                    info["buttons"] += f"<button style='margin-top:4px;font-size:10px;' onclick=\"setPrepTargets('{target_str}')\">Redefine Targets</button>"
                 slot_infos[str(slot)] = info
 
         template_path = files('AFL.automation.driver_templates').joinpath('ot2_deck.html')


### PR DESCRIPTION
## Summary
- store OT-2 prep targets in persistent config
- expose buttons in deck GUI to append or redefine prep targets
- add JavaScript helpers for prep target actions
- reset prep targets when deck is reset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6855a2fb84cc832b80d5c99b6b51b264