### PR TITLE
Add prep target management in OT2HTTPDriver

### DIFF
--- a/AFL/automation/driver_templates/ot2_deck.html
+++ b/AFL/automation/driver_templates/ot2_deck.html
@@ -23,6 +23,10 @@ body { font-family: Arial, sans-serif; margin: 20px; background-color: #fafafa; 
 svg circle:hover, svg rect:hover { stroke-width: 2 !important; stroke: #ff5722 !important; }
 .ui-dialog {border: solid black;}
 .ui-dialog-content, .ui-dialog { background: #fff !important; border-radius: 2px; }
+.well-select-table { border-collapse: collapse; margin: 10px auto; }
+.well-select-table th, .well-select-table td { border: 1px solid #ccc; width: 24px; height: 24px; text-align: center; cursor: pointer; font-size: 12px; }
+.well-select-table td.selected { background: #4caf50; color: #fff; }
+.well-select-table th.row-header, .well-select-table th.col-header { background: #eee; font-weight: bold; }
 </style>
 </head>
 <body>
@@ -128,6 +132,87 @@ function resetTipracks(mount) {
             url:"/enqueue",
             headers:{"Content-Type":"application/json","Authorization":"Bearer "+tok},
             data: JSON.stringify({task_name:"reset_tipracks", mount: mount}),
+            success: function() { location.reload(); },
+            error: function(xhr) { alert("Error: "+xhr.responseText); }
+        });
+    });
+}
+function openPrepTargetDialog(slot, targets, mode) {
+    var wells = targets.split(',').map(function(t){ return t.replace(/^\d+/, ''); });
+    var rows = [];
+    var cols = [];
+    wells.forEach(function(w){
+        var m = w.match(/([A-Za-z]+)(\d+)/);
+        if(!m) return;
+        if(rows.indexOf(m[1]) === -1) rows.push(m[1]);
+        var c = parseInt(m[2]);
+        if(cols.indexOf(c) === -1) cols.push(c);
+    });
+    rows.sort();
+    cols.sort(function(a,b){return a-b;});
+    var table = $('<table class="well-select-table"></table>');
+    var header = $('<tr><th></th></tr>');
+    cols.forEach(function(c){ header.append('<th class="col-header" data-col="'+c+'">'+c+'</th>'); });
+    table.append(header);
+    rows.forEach(function(r){
+        var row = $('<tr></tr>');
+        row.append('<th class="row-header" data-row="'+r+'">'+r+'</th>');
+        cols.forEach(function(c){
+            var cell = $('<td class="well-cell" data-row="'+r+'" data-col="'+c+'" data-well="'+slot+r+c+'"></td>');
+            row.append(cell);
+        });
+        table.append(row);
+    });
+    table.on('click','.well-cell',function(){ $(this).toggleClass('selected'); });
+    table.on('click','.row-header',function(){
+        var r=$(this).data('row');
+        var cells=table.find('.well-cell[data-row="'+r+'"]');
+        var sel=cells.filter('.selected').length===cells.length;
+        cells.toggleClass('selected', !sel);
+    });
+    table.on('click','.col-header',function(){
+        var c=$(this).data('col');
+        var cells=table.find('.well-cell[data-col="'+c+'"]');
+        var sel=cells.filter('.selected').length===cells.length;
+        cells.toggleClass('selected', !sel);
+    });
+    var dialog = $('<div></div>').append(table).dialog({
+        title: (mode==='append'?'Append':'Redefine')+' Prep Targets',
+        modal:true,
+        width:'auto',
+        buttons:{
+            'Confirm': function(){
+                var list=table.find('.well-cell.selected').map(function(){return $(this).data('well');}).get();
+                if(list.length===0){ alert('Select at least one well'); return; }
+                var str=list.join(',');
+                if(mode==='append'){ appendPrepTargets(str); } else { setPrepTargets(str); }
+                dialog.dialog('destroy').remove();
+            },
+            'Cancel': function(){ dialog.dialog('destroy').remove(); }
+        }
+    });
+}
+function appendPrepTargets(targets) {
+    var t = targets.split(',');
+    login().then(function(tok) {
+        $.ajax({
+            type:"POST",
+            url:"/enqueue",
+            headers:{"Content-Type":"application/json","Authorization":"Bearer "+tok},
+            data: JSON.stringify({task_name:"add_prep_targets", targets: t, reset:false}),
+            success: function() { location.reload(); },
+            error: function(xhr) { alert("Error: "+xhr.responseText); }
+        });
+    });
+}
+function setPrepTargets(targets) {
+    var t = targets.split(',');
+    login().then(function(tok) {
+        $.ajax({
+            type:"POST",
+            url:"/enqueue",
+            headers:{"Content-Type":"application/json","Authorization":"Bearer "+tok},
+            data: JSON.stringify({task_name:"add_prep_targets", targets: t, reset:true}),
             success: function() { location.reload(); },
             error: function(xhr) { alert("Error: "+xhr.responseText); }
         });

--- a/AFL/automation/prepare/OT2HTTPDriver.py
+++ b/AFL/automation/prepare/OT2HTTPDriver.py
@@ -31,7 +31,8 @@ class OT2HTTPDriver(Driver):
     defaults["loaded_labware"] = {}  # Persistent storage for loaded labware
     defaults["loaded_instruments"] = {}  # Persistent storage for loaded instruments
     defaults["loaded_modules"] = {}  # Persistent storage for loaded modules
-    defaults["available_tips"] = {} # Persistent storage for available tips, Format: {mount: [(tiprack_id, well_name), ...]}
+    defaults["available_tips"] = {}  # Persistent storage for available tips, Format: {mount: [(tiprack_id, well_name), ...]}
+    defaults["prep_targets"] = []  # Persistent storage for prep target well locations
 
     def __init__(self, overrides=None):
         self.app = None
@@ -48,7 +49,6 @@ class OT2HTTPDriver(Driver):
         self.protocol_id = None
         self.max_transfer = None
         self.min_transfer = None
-        self.prep_targets = []
         self.has_tip = False
         self.last_pipette = None
         self.modules = {}
@@ -180,21 +180,27 @@ class OT2HTTPDriver(Driver):
             raise RuntimeError(f"Error getting pipettes: {str(e)}")
 
     def reset_prep_targets(self):
-        self.prep_targets = []
+        """Clear the list of preparation targets stored in the config."""
+        self.config["prep_targets"] = []
+
 
     def add_prep_targets(self, targets, reset=False):
+        """Add well locations to the preparation target list."""
         if reset:
             self.reset_prep_targets()
-        self.prep_targets.extend(targets)
+        self.config.setdefault("prep_targets", [])
+        self.config["prep_targets"].extend(listify(targets))
+        self.config._update_history()
 
     def get_prep_target(self):
-        return self.prep_targets.pop(0)
+        return self.config["prep_targets"].pop(0)
 
     def status(self):
         status = []
-        if len(self.prep_targets) > 0:
-            status.append(f"Next prep target: {self.prep_targets[0]}")
-            status.append(f"Remaining prep targets: {len(self.prep_targets)}")
+        prep_targets = self.config.get("prep_targets", [])
+        if len(prep_targets) > 0:
+            status.append(f"Next prep target: {prep_targets[0]}")
+            status.append(f"Remaining prep targets: {len(prep_targets)}")
         else:
             status.append("No prep targets loaded")
 
@@ -309,6 +315,7 @@ class OT2HTTPDriver(Driver):
         self.config["loaded_instruments"] = {}
         self.config["loaded_modules"] = {}
         self.config["available_tips"] = {}
+        self.config["prep_targets"] = []
 
     @Driver.quickbar(qb={"button_text": "Home"})
     def home(self, **kwargs):
@@ -1921,6 +1928,17 @@ class OT2HTTPDriver(Driver):
                     'tiprack' in labware_type.lower() or
                     definition.get('metadata', {}).get('displayCategory') == 'tipRack'
                 )
+                wells = list(definition.get('wells', {}).keys())
+                # sort wells in row-major order (A1, A2, B1, B2, ...)
+                def _well_key(w):
+                    import re
+                    m = re.match(r"([A-Za-z]+)(\d+)", w)
+                    if m:
+                        row = m.group(1)
+                        col = int(m.group(2))
+                        return (row, col)
+                    return (w, 0)
+                wells = sorted(wells, key=_well_key)
                 mounts = []
                 if is_tiprack:
                     for m, d in self.config['loaded_instruments'].items():
@@ -1936,6 +1954,8 @@ class OT2HTTPDriver(Driver):
                     info['tiprack'] = True
                     info['mounts'] = mounts
                     info['color'] = '#fff3e0'
+                info['target_count'] = len(wells)
+                info['targets'] = ','.join([f"{slot_str}{w}" for w in wells])
             if has_module:
                 module_id, module_type = self.config["loaded_modules"][slot_str]
                 module_name = module_type.replace('ModuleV1', '').replace('Module', ' Mod')
@@ -1963,6 +1983,18 @@ class OT2HTTPDriver(Driver):
                     f"<button style='margin-top:4px;font-size:10px;' onclick=\"resetTipracks('{m}')\">Reset</button>"
                     for m in info.get('mounts', [])
                 ])
+                if info.get('target_count', 0) > 10:
+                    target_str = info.get('targets', '')
+                    info["buttons"] += (
+                        f"<button style='margin-top:4px;font-size:10px;' "
+                        f"onclick=\"openPrepTargetDialog('{slot_str}','{target_str}','append')\">"
+                        "Append Targets</button>"
+                    )
+                    info["buttons"] += (
+                        f"<button style='margin-top:4px;font-size:10px;' "
+                        f"onclick=\"openPrepTargetDialog('{slot_str}','{target_str}','set')\">"
+                        "Redefine Targets</button>"
+                    )
                 slot_infos[str(slot)] = info
 
         template_path = files('AFL.automation.driver_templates').joinpath('ot2_deck.html')


### PR DESCRIPTION
## Summary
- store OT-2 prep targets in persistent config
- expose buttons in deck GUI to append or redefine prep targets
- add JavaScript helpers for prep target actions
- reset prep targets when deck is reset
- ensure targets are sorted row-major (A1, A2, B1...)
- allow selecting individual wells when adding prep targets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6855a2fb84cc832b80d5c99b6b51b264