### PR TITLE
Enable custom labware in OT2HTTPDriver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,6 @@ packages = ["AFL"]
 
 [tool.hatch.build.targets.sdist]
 packages = ["AFL"]
+
+[tool.afl]
+custom_labware_dir = "support/labware"

--- a/support/labware/example_labware.json
+++ b/support/labware/example_labware.json
@@ -1,0 +1,12 @@
+{
+  "namespace": "custom_beta",
+  "parameters": {"loadName": "example_labware"},
+  "version": 1,
+  "schemaVersion": 2,
+  "metadata": {
+    "displayName": "Example Labware",
+    "displayCategory": "wellPlate"
+  },
+  "wells": {},
+  "ordering": []
+}


### PR DESCRIPTION
## Summary
- add `[tool.afl]` section with `custom_labware_dir`
- load custom labware jsons from the support directory
- send custom definitions to the robot when loading
- cache custom labware on disk
- add example custom labware definition
- refine custom labware handling

## Testing
- `pytest -q` *(fails: 2 tests failing in mass balance)*

------
https://chatgpt.com/codex/tasks/task_e_6855a1d75b54832ba8489691d5c3ed08