### PR TITLE
Remove SMTP email logging

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     _HAVE_WAITRESS = False
 
-from logging.handlers import SMTPHandler
 from logging import FileHandler
 
 from AFL.automation.APIServer.QueueDaemon import QueueDaemon
@@ -293,17 +292,8 @@ class APIServer:
     def init_logging(self,toaddrs=None):
         self.app.logger.setLevel(level=logging.DEBUG)
 
-        if toaddrs is not None:
-            # setup error emails
-            mail_handler = SMTPHandler(mailhost=('smtp.nist.gov',25),
-                               fromaddr=f'{self.name}@pg903001.ncnr.nist.gov',
-                               toaddrs=toaddrs,
-                               subject='Driver Error')
-            mail_handler.setLevel(logging.ERROR)
-            self.app.logger.addHandler(mail_handler)
-
-
-
+        # SMTP email handling has been removed. The `toaddrs` argument is now
+        # ignored and retained only for backwards compatibility.
         path = pathlib.Path.home() / '.afl'
         path.mkdir(exist_ok=True,parents=True)
         filepath = path / f'{self.name}.log'


### PR DESCRIPTION
## Summary
- drop SMTPHandler import
- remove email setup in `init_logging`

## Testing
- `pip install -e .` *(fails: preparing editable metadata)*
- `pip install pandas`
- `pip install pint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'periodictable', 'scipy')*


------
https://chatgpt.com/codex/tasks/task_e_685ae83dfdf0832bafc4d7ed25ed9dd2