### PR TITLE
Disable Waitress console warnings

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -18,6 +18,8 @@ import threading,queue,logging,json,pathlib,uuid
 try:
     from waitress import serve as wsgi_serve
     _HAVE_WAITRESS = True
+    # Silence verbose logging from waitress which can flood the console
+    logging.getLogger("waitress").setLevel(logging.ERROR)
 except ImportError:
     _HAVE_WAITRESS = False
 


### PR DESCRIPTION
## Summary
- quiet the `waitress` logger when starting APIServer

## Testing
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 python -m pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afd5f0548832b985afb177e10d824