### PR TITLE
Clarify GET vs POST for unqueued endpoints

### DIFF
--- a/docs/source/explanation/user-interfaces.rst
+++ b/docs/source/explanation/user-interfaces.rst
@@ -50,6 +50,15 @@ Valid values of `render_hint` are ['raw','precomposed_svg','precomposed_jpg','1d
 
 The other kwargs can be provided in the function decorator, but will be overridden with URL arguments, so the user can change the plot from log to lin (say) from the client.
 
+.. note::
+
+   Unqueued functions are served via HTTP ``GET`` routes and are intended for
+   read-only queries.  Any action that modifies state must be submitted to the
+   server's ``/enqueue`` endpoint using a ``POST`` request with a valid JWT
+   token obtained from ``/login``.  A common pattern is for a user interface to
+   stage changes locally and then send them as one queued task, rather than
+   calling unqueued endpoints with ``POST``.
+
 
 
 2. **Quickbar Decorator**


### PR DESCRIPTION
## Summary
- document that unqueued driver functions are served via GET
- explain using `/enqueue` with a token for state-changing operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0605b358832b823fba1326c28202